### PR TITLE
Refactor to use state/reducer pattern, per docs

### DIFF
--- a/todomvc/assets/index-dev.html
+++ b/todomvc/assets/index-dev.html
@@ -5,7 +5,12 @@
   <title>TodoMVC on Outwatch</title>
 </head>
 <body>
-  <div id="outwatch_todomvc_main"></div>
+  <section id="todoapp"></section>
+  <footer class="info">
+    <p>Double-click to edit a todo</p>
+    <p>Created by <a href="https://github.com/OutWatch/outwatch">OutWatch</a></p>
+    <p>Part of <a href="http://todomvc.com">TodoMVC</a></p>
+  </footer>
   <script type="text/javascript" src="outwatch-examples-todomvc-fastopt-library.js"></script>
   <script type="text/javascript" src="outwatch-examples-todomvc-fastopt-loader.js"></script>
   <script type="text/javascript" src="outwatch-examples-todomvc-fastopt.js"></script>

--- a/todomvc/assets/index.html
+++ b/todomvc/assets/index.html
@@ -5,7 +5,12 @@
   <title>TodoMVC on Outwatch</title>
 </head>
 <body>
-  <div id="outwatch_todomvc_main"></div>
+  <section id="todoapp"></section>
+  <footer class="info">
+    <p>Double-click to edit a todo</p>
+    <p>Created by <a href="https://github.com/OutWatch/outwatch">OutWatch</a></p>
+    <p>Part of <a href="http://todomvc.com">TodoMVC</a></p>
+  </footer>
   <script type="text/javascript" src="outwatch-examples-todomvc-opt-bundle.js"></script>
 </body>
 </html>

--- a/todomvc/src/main/scala/todomvc/Main.scala
+++ b/todomvc/src/main/scala/todomvc/Main.scala
@@ -5,6 +5,6 @@ import monix.execution.Scheduler.Implicits.global
 
 object TodoMvcMain{
   def main(args: Array[String]): Unit = {
-    TodoMvc().flatMap(OutWatch.renderReplace("#outwatch_todomvc_main", _)).unsafeRunSync()
+    TodoMvc().render().flatMap(OutWatch.renderInto("#todoapp", _)).unsafeRunSync()
   }
 }

--- a/todomvc/src/main/scala/todomvc/domain.scala
+++ b/todomvc/src/main/scala/todomvc/domain.scala
@@ -1,0 +1,74 @@
+package todomvc
+
+import cats.effect.IO
+import monix.execution.Scheduler
+import outwatch.dom.ProHandler
+import outwatch.util.Store
+
+final case class TodoItem(id: Int, title: String, completed: Boolean)
+
+sealed abstract class Selection(val name: String) extends Product with Serializable{
+  def url: String = s"#/$name"
+  def pred(t: TodoItem): Boolean
+}
+
+object Selection {
+  case object All extends Selection("all"){ def pred(t: TodoItem) = true }
+  case object Active extends Selection("active"){ def pred(t: TodoItem) = !t.completed }
+  case object Completed extends Selection("completed"){ def pred(t: TodoItem) = t.completed }
+  def selections: List[Selection] = All :: Active :: Completed :: Nil
+}
+
+sealed abstract class Action extends Product with Serializable
+object Action{
+  case object AddTodo extends Action
+  case class UpdateText(text: String) extends Action
+  case class RemoveTodo(id: Int) extends Action
+  case class UpdateTodo(id: Int, newText: String) extends Action
+  case class ToggleTodo(id: Int) extends Action
+  case object AllComplete extends Action
+  case class Drop(pred: TodoItem => Boolean) extends Action
+  case class UpdateFilter(selection: Selection) extends Action
+}
+
+final case class AppState(
+  nextId: Int,
+  todos: List[TodoItem],
+  text: String,
+  selection: Selection
+)
+
+object AppState {
+  import Action._
+
+  private def updateById(id: Int, state: AppState)(update: TodoItem => TodoItem): AppState = {
+    state.todos.find(_.id == id).map{ todo =>
+      state.copy(todos = update(todo) :: state.todos.filterNot(_.id == id))
+    }.getOrElse(state)
+  }
+
+  def reducer(state: AppState, action: Action): AppState = action match {
+    case AddTodo => state.copy(
+      nextId = state.nextId + 1,
+      todos = TodoItem(state.nextId, state.text, false) :: state.todos,
+      text = ""
+    )
+    case UpdateText(text) => state.copy(text = text)
+    case RemoveTodo(id) => state.copy(
+      todos = state.todos.filterNot(_.id == id)
+    )
+    case UpdateTodo(id, newText) => updateById(id, state)(_.copy(title = newText))
+    case ToggleTodo(id) => updateById(id, state)(x => x.copy(completed = !x.completed))
+    case AllComplete => state.copy(todos = state.todos.map(_.copy(completed = true)))
+    case Drop(pred) => state.copy(todos = state.todos.filterNot(pred))
+    case UpdateFilter(selection: Selection) => state.copy(selection = selection)
+  }
+
+  type AppStore = ProHandler[Action, AppState]
+  type SubStore[A] = ProHandler[Action, A]
+  type AppReducer = Store.Reducer[AppState, Action]
+  val AppReducer = Store.Reducer
+  def appReducer : AppReducer = AppReducer.justState(reducer _)
+  def appStore(implicit S: Scheduler): IO[AppStore] =
+    Store.create(AppState(0, Nil, "", Selection.All), appReducer)
+}

--- a/todomvc/webpack.config.dev.js
+++ b/todomvc/webpack.config.dev.js
@@ -9,9 +9,7 @@ module.exports.devServer = {
            Path.resolve(__dirname, 'dev'), // fastOptJS output
            Path.resolve(rootDir, 'assets') // project root containing index.html
     ],
-    historyApiFallback: {rewrites: [
-        {from: /^$/, to: '/index-dev.html' },
-        {from: /./, to: '/index-dev.html' }]},
+    historyApiFallback: true,
     index: 'index-dev.html',
     watchContentBase: true,
     hot: false,


### PR DESCRIPTION
Much easier this way.  Fixes #2, #5, #6.

Instead of trying to encapsulate each minor component with its own handler, use the global state and reducer pattern.